### PR TITLE
feat: add ElevenLabs speech-to-text custom hook and mock implementati…

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -153,6 +153,10 @@ const config = {
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
 
+  moduleNameMapper: {
+    "^elevenlabs$": "<rootDir>/mocks/elevenlabs.js",
+  },
+
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
 
@@ -160,6 +164,7 @@ const config = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
+  
   testEnvironment: "jsdom",
 
   // Options that will be passed to the testEnvironment

--- a/mocks/elevenlabs.js
+++ b/mocks/elevenlabs.js
@@ -1,0 +1,9 @@
+export const convertMock = jest.fn().mockResolvedValue({ text: "Texto de prueba" });
+
+export class ElevenLabsClient {
+  constructor() {
+    this.speechToText = {
+      convert: convertMock,
+    };
+  }
+}

--- a/tests/transacciones/elevenlabsSTT.test.jsx
+++ b/tests/transacciones/elevenlabsSTT.test.jsx
@@ -1,0 +1,163 @@
+import { renderHook, act } from "@testing-library/react";
+import { useElevenLabsSTT } from "../../utils/elevenlabsSTT"; // ajusta esta ruta
+import { ElevenLabsClient } from "elevenlabs";
+
+global.navigator.mediaDevices = {
+  getUserMedia: jest.fn().mockResolvedValue({
+    getTracks: () => [{ stop: jest.fn() }],
+  }),
+};
+
+// Mock de MediaRecorder actualizado
+global.MediaRecorder = class {
+    constructor() {
+      this.state = "inactive";
+      this.ondataavailable = null;
+      this.onstop = null;
+  
+      // Definir `stop` como mock
+      this.stop = jest.fn(() => {
+        this.state = "inactive";
+        if (this.onstop) this.onstop();
+      });
+  
+      this.start = jest.fn(() => {
+        this.state = "recording";
+        setTimeout(() => {
+          if (this.ondataavailable) {
+            const dummyBlob = new Blob(["audio de prueba"], { type: "audio/webm" });
+            this.ondataavailable({ data: dummyBlob });
+          }
+          if (this.onstop) {
+            this.state = "inactive";
+            this.onstop();
+          }
+        }, 100); // Simula un pequeño delay
+      });
+    }
+  };
+  
+
+global.AudioContext = class {
+  constructor() {
+    this.createAnalyser = jest.fn(() => ({
+      fftSize: 2048,
+      getByteTimeDomainData: jest.fn((data) => {
+        for (let i = 0; i < data.length; i++) {
+          data[i] = 128; // Valor constante = silencio
+        }
+      }),
+    }));
+    this.createMediaStreamSource = jest.fn(() => ({
+      connect: jest.fn(),
+    }));
+    this.close = jest.fn();
+  }
+};
+
+global.requestAnimationFrame = (cb) => setTimeout(cb, 16);
+global.cancelAnimationFrame = (id) => clearTimeout(id);
+
+jest.mock("elevenlabs", () => {
+  return {
+    ElevenLabsClient: jest.fn().mockImplementation(() => {
+      return {
+        speechToText: {
+          convert: jest.fn().mockResolvedValue({ text: "Texto de prueba" }),
+        },
+      };
+    }),
+  };
+});
+
+jest.useFakeTimers(); // Para controlar setTimeout usado en el mock de MediaRecorder
+
+describe("useElevenLabsSTT", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("debería inicializar con los valores por defecto", () => {
+    const { result } = renderHook(() => useElevenLabsSTT());
+
+    expect(result.current.transcript).toBe("");
+    expect(result.current.listening).toBe(false);
+    expect(result.current.supportsSpeechRecognition).toBe(true);
+    expect(typeof result.current.start).toBe("function");
+    expect(typeof result.current.stop).toBe("function");
+    expect(typeof result.current.resetTranscript).toBe("function");
+  });
+
+  it("debería iniciar grabación y actualizar transcript después de detenerse", async () => {
+    const { result } = renderHook(() => useElevenLabsSTT());
+
+    await act(async () => {
+      await result.current.start();
+      jest.runAllTimers();
+
+      // Asegurarnos de que la promesa se resuelva correctamente
+      await Promise.resolve(); // Asegura que las microtareas se resuelvan
+    });
+
+    console.log(
+      "Transcript después de ejecutar todo:",
+      result.current.transcript
+    );
+
+    expect(result.current.listening).toBe(false);
+    expect(result.current.transcript).toBe("Texto de prueba");
+  });
+
+  it("debería manejar el error si la conversión de audio falla", async () => {
+    // Hacemos que `convert` lance un error
+    jest.mock("elevenlabs", () => {
+      return {
+        ElevenLabsClient: jest.fn().mockImplementation(() => {
+          return {
+            speechToText: {
+              convert: jest.fn().mockRejectedValue(new Error("Error en la conversión")),
+            },
+          };
+        }),
+      };
+    });
+  
+    const { result } = renderHook(() => useElevenLabsSTT());
+  
+    await act(async () => {
+      await result.current.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+  
+    expect(result.current.listening).toBe(false);
+    expect(result.current.transcript).toBe("Texto de prueba");
+    // Aquí podrías verificar si el error se muestra en consola o hacer alguna comprobación adicional
+  });
+
+  it("debería restablecer el transcript correctamente", async () => {
+    const { result } = renderHook(() => useElevenLabsSTT());
+  
+    await act(async () => {
+      await result.current.start();
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+  
+    // Cambiar el transcript
+    expect(result.current.transcript).toBe("Texto de prueba");
+  
+    // Restablecer el transcript
+    act(() => {
+      result.current.resetTranscript();
+    });
+  
+    expect(result.current.transcript).toBe("");
+  });
+
+  it("debería detectar que el navegador sí soporta la grabación de audio", () => {
+    const { result } = renderHook(() => useElevenLabsSTT());
+  
+    expect(result.current.supportsSpeechRecognition).toBe(true);
+  });
+});

--- a/utils/elevenlabsSTT.js
+++ b/utils/elevenlabsSTT.js
@@ -1,9 +1,22 @@
+import React, { useState, useRef } from "react";
 import { ElevenLabsClient } from "elevenlabs";
 
 const client = new ElevenLabsClient({
   apiKey: process.env.NEXT_PUBLIC_ELEVENLABS_API_KEY,
 });
 
+/**
+ * Custom hook for speech-to-text functionality using ElevenLabs API.
+ * Provides methods to start and stop audio recording, detect silence, and process audio into text.
+ *
+ * @returns {Object} An object containing:
+ * - `transcript` {string}: The transcribed text from the audio.
+ * - `listening` {boolean}: Indicates whether the recording is currently active.
+ * - `supportsSpeechRecognition` {boolean}: Indicates if the browser supports MediaRecorder.
+ * - `start` {Function}: Starts the audio recording and transcription process.
+ * - `stop` {Function}: Stops the audio recording and transcription process.
+ * - `resetTranscript` {Function}: Resets the transcript to an empty string.
+ */
 export const useElevenLabsSTT = () => {
   const [transcript, setTranscript] = useState("");
   const [listening, setListening] = useState(false);


### PR DESCRIPTION
This pull request introduces a new mock implementation for the ElevenLabs speech-to-text functionality and adds comprehensive tests for the `useElevenLabsSTT` custom hook. The changes include creating a mock client for ElevenLabs, updating the test environment to support audio recording, and adding multiple test cases to ensure the hook functions correctly.

Mock implementation and client setup:

* [`mocks/elevenlabs.js`](diffhunk://#diff-1e0135e6e0a5b71e519fb470e064e6c9311c8f8c0668e71c831eec5f694c24c0R1-R9): Created a mock implementation for the ElevenLabs client with a `convertMock` function to simulate speech-to-text conversion.

Testing enhancements:

* [`tests/transacciones/elevenlabsSTT.test.jsx`](diffhunk://#diff-284ade1e3fc1d47f06cb339bec4b2fb7215663489b8e63c620c2e5116282fd67R1-R163): Added tests for the `useElevenLabsSTT` hook, including initialization, starting/stopping recording, handling conversion errors, and resetting the transcript. The test environment was updated to mock `MediaRecorder`, `AudioContext`, and other necessary browser APIs.

Custom hook documentation and improvements:

* [`utils/elevenlabsSTT.js`](diffhunk://#diff-ed5d83dbbf22b6c7998a30c5efbe76c02f9459173819c8cb231ca731d6f6552dR1-R19): Added JSDoc comments to the `useElevenLabsSTT` hook for better documentation and understanding of its functionality.